### PR TITLE
Fix reference to seismograph svg path

### DIFF
--- a/components/molecules/Seismograph.js
+++ b/components/molecules/Seismograph.js
@@ -3,7 +3,7 @@ const Seismograph = ({children}) => {
   return (
     <div className="relative flex justify-center">
       <img
-        src={urlPrefix + '/seismograph.svg'}
+        src={urlPrefix + '/Seismograph.svg'}
         alt="Generative art looking like a seismogram based on digital interactions in Kodeworks"
       />
       {children}


### PR DESCRIPTION
Github Pages serve the file with a capitalized first letter.