### PR TITLE
Always run test-report after completed CI

### DIFF
--- a/.github/workflows/kodeworks-CI.yml
+++ b/.github/workflows/kodeworks-CI.yml
@@ -39,14 +39,10 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn test:ci
       - uses: actions/upload-artifact@v2 # upload test results for test-report.yml
-        if: success() || failure() # run this step even if previous step failed
+        if: always() # run this step even if previous step failed
         with:
           name: test-results
           path: reports/jest-junit.xml
-      - name: Set flag to run Test Report
-        if: always() # run this step even if previous step failed
-        run: echo '::set-output name=RUN_TEST_REPORT::true'
-        id: random-color-generator
 
   build-and-export-static-pages:
     needs: [tests]

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -6,10 +6,8 @@ on:
       - completed
 jobs:
   report:
-    if: ${{ github.event.workflow_run.tests.outputs.RUN_TEST_REPORT == 'true'}}
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Test Report running since RUN_TEST_REPORT flag in Continous integration workflow is set to true."
       - uses: dorny/test-reporter@v1
         with:
           artifact: test-results # artifact name


### PR DESCRIPTION
Make test report run after tests to see how the test report behaves with failing tests, and if the artifact uploaded by the tests-step does not exist. 