### PR TITLE
Set action as success even if test report contains failed test

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -14,3 +14,4 @@ jobs:
           name: JEST Tests # Name of the check run which will be created
           path: 'jest-junit.xml' # Path to test results (inside artifact .zip)
           reporter: jest-junit # Format of test results
+          fail-on-error: 'false'

--- a/tests/__tests__/pages/index.test.js
+++ b/tests/__tests__/pages/index.test.js
@@ -1,6 +1,10 @@
 import {render, screen} from '@testing-library/react'
 import Home from 'pages/index'
 
+test('failing test', async () => {
+  expect(false).toBe(true)
+})
+
 test('renders page', async () => {
   render(<Home />)
 })

--- a/tests/__tests__/pages/index.test.js
+++ b/tests/__tests__/pages/index.test.js
@@ -1,10 +1,6 @@
 import {render, screen} from '@testing-library/react'
 import Home from 'pages/index'
 
-test('failing test', async () => {
-  expect(false).toBe(true)
-})
-
 test('renders page', async () => {
   render(<Home />)
 })


### PR DESCRIPTION
Don't need to fail the test reporter since the tests step will fail if there are failing tests. 

Test reporter failing: 
<img width="368" alt="Screenshot 2021-08-24 at 20 04 50" src="https://user-images.githubusercontent.com/6596033/130667312-6ad141cf-a1cd-43d7-8f9b-c6b765d43dc7.png">

Tests step failing: 
<img width="274" alt="Screenshot 2021-08-24 at 20 05 04" src="https://user-images.githubusercontent.com/6596033/130667331-7cd5a4ce-4a0c-4689-bfbd-ff1dc39376a5.png">

Result of failing test in action overview: 
<img width="1229" alt="Screenshot 2021-08-24 at 20 00 17" src="https://user-images.githubusercontent.com/6596033/130667535-c297916f-5fcb-4e5c-a9b5-7380431bdef3.png">

Code annotation from Test Reporter when test fail: 
<img width="1746" alt="Screenshot 2021-08-24 at 19 59 41" src="https://user-images.githubusercontent.com/6596033/130667578-f64dde53-99a9-4b9c-a3d0-5161413f3215.png">
