### PR TITLE
Rename test report action and update readme

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: dorny/test-reporter@v1
         with:
           artifact: test-results # artifact name
-          name: JEST Tests # Name of the check run which will be created
+          name: Test report # Name of the check run which will be created
           path: 'jest-junit.xml' # Path to test results (inside artifact .zip)
           reporter: jest-junit # Format of test results
           fail-on-error: 'false'

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ Used for change-detection, so that steps unrelated to changed files don't have t
 
 ## Test Report
 
-> 💡 Show in Github PR if tests passed, failed or were skipped  
-> Annotate code where tests failed
+> 💡 Test report available in `Continous Integration`-action under `Test report`-step.
+> Code in `files changed`-tab in PR is annotate with details from the test report where tests failed.
 
-Trigger: `Continous Integration` job completed  
-If-Checks: `RUN_TEST_REPORT` flag in `Continous integration` workflow is set to `"true"`  
+Trigger: `Continous Integration` job completed
 Definition: `./github/workflows/test-report.yml`  
 Documentation: [Test Reporter Github repo](https://github.com/dorny/test-reporter)
 


### PR DESCRIPTION
this PR renames the test report action from `JEST tests` to `Test report`: 
<img width="353" alt="Screenshot 2021-08-24 at 20 21 16" src="https://user-images.githubusercontent.com/6596033/130671055-95dee4b2-814d-4252-b351-b8174e4cb3f3.png">

This PR also updates the test report section in the readme with info about where the test report and code annotation is available
